### PR TITLE
Add WAF matchstrings support, Cloudmare for cloudflare realip detection and DOMAIN tag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -477,7 +477,7 @@ Documentation writing in progress...
 Supported Services & Security Checks 
 =====================================
 
-**Updated on: 11/06/2019**
+**Updated on: 12/07/2019**
 
 **Lots of checks remain to be implemented and services must be added !! Work in progress ...**
 
@@ -548,6 +548,7 @@ HTTP (default 80/tcp)
     | load-balancing-detection                 | recon        | HTTP load balancer detection                                                                   | halberd                       |
     | waf-detection                            | recon        | Identify and fingerprint WAF products protecting website                                       | wafw00f                       |
     | waf-detection2                           | recon        | Identify and fingerprint WAF products protecting website                                       | identifywaf                   |
+    | cloudmare-recon                          | recon        | CloudFlare real IP catcher                                                                     | cloudmare                     |
     | fingerprinting-multi-whatweb             | recon        | Identify CMS, blogging platforms, JS libraries, Web servers                                    | whatweb                       |
     | fingerprinting-appserver                 | recon        | Fingerprint application server (JBoss, ColdFusion, Weblogic, Tomcat, Railo, Axis2, Glassfish)  | clusterd                      |
     | webdav-detection-msf                     | recon        | Detect WebDAV on webserver                                                                     | metasploit                    |

--- a/lib/core/Command.py
+++ b/lib/core/Command.py
@@ -25,6 +25,7 @@ General Tags
 [WEBSHELLSDIR]    Webshells directory
 [WORDLISTSDIR]    Wordlists directory
 [LOCALIP]         Local IP address
+[DOMAIN]          Root domain name (e.g. site.com)
 
 Bruteforce Options Tags
 -----------------------
@@ -79,7 +80,7 @@ import urllib.parse
 from lib.core.Config import *
 from lib.core.Constants import *
 from lib.utils.NetUtils import NetUtils
-
+from tld import get_tld
 
 class Command:
 
@@ -136,6 +137,7 @@ class Command:
                 self.__replace_tag_ip(target.get_ip())
                 self.__replace_tag_url(target.get_url())
                 self.__replace_tag_uripath(target.get_url())
+                self.__replace_tag_domain(target.get_url())
                 self.__replace_tag_host(target.get_host(), target.get_ip())
                 self.__replace_tag_port(target.get_port())
                 self.__replace_tag_protocol(target.get_protocol())
@@ -189,6 +191,20 @@ class Command:
         pattern = re.compile('\[URL\]', re.IGNORECASE)
         self.formatted_cmdline = pattern.sub(url, self.formatted_cmdline)
 
+    def __replace_tag_domain(self, url):
+        """
+        Replace tag [DOMAIN] by the target URL root domain in self.formatted_cmdline.
+
+        :param str url: Target URL
+        """
+        if not url: return
+        pattern = re.compile('\[DOMAIN\]', re.IGNORECASE)
+        try:
+            res = get_tld(url, as_object=True)
+            domain = res.fld
+        except Exception as e:
+            domain = ''
+        self.formatted_cmdline = pattern.sub(domain, self.formatted_cmdline)
 
     def __replace_tag_uripath(self, url):
         """
@@ -201,7 +217,7 @@ class Command:
         try:
             o = urllib.parse.urlparse(url)
             uripath = o.path or '/'
-        except:
+        except Exception as e:
             uripath = '/'
 
         self.formatted_cmdline = pattern.sub(uripath, self.formatted_cmdline)

--- a/lib/reporter/Reporter.py
+++ b/lib/reporter/Reporter.py
@@ -220,6 +220,7 @@ class Reporter:
                     product_types = (
                         'web-server',
                         'web-appserver',
+                        'web-application-firewall',
                         'web-cms',
                         'web-language',
                         'web-framework',
@@ -419,6 +420,7 @@ class Reporter:
                 product_types = (
                     'web-server',
                     'web-appserver',
+                    'web-application-firewall',
                     'web-cms',
                     'web-language',
                     'web-framework',

--- a/lib/reporter/templates/index.tpl.html
+++ b/lib/reporter/templates/index.tpl.html
@@ -359,6 +359,9 @@
     .badge-web-framework {
         background-color: #65ead7;
     }
+    .badge-web-application-firewall {
+        background-color: #f48120;
+    }
     .badge-web-jslib {
         background-color: #ea9d65;
     }

--- a/lib/smartmodules/matchstrings/MatchStrings.py
+++ b/lib/smartmodules/matchstrings/MatchStrings.py
@@ -81,6 +81,7 @@ products_match = defaultdict(dict)
 from lib.smartmodules.matchstrings.products.AjpServerProducts import *
 from lib.smartmodules.matchstrings.products.FtpServerProducts import *
 from lib.smartmodules.matchstrings.products.HttpWebAppserverProducts import *
+from lib.smartmodules.matchstrings.products.HttpWebApplicationFirewallProducts import *
 from lib.smartmodules.matchstrings.products.HttpWebCmsProducts import *
 from lib.smartmodules.matchstrings.products.HttpWebFrameworkProducts import *
 from lib.smartmodules.matchstrings.products.HttpWebJslibProducts import *

--- a/lib/smartmodules/matchstrings/products/HttpWebApplicationFirewallProducts.py
+++ b/lib/smartmodules/matchstrings/products/HttpWebApplicationFirewallProducts.py
@@ -1,0 +1,616 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from lib.smartmodules.matchstrings.MatchStrings import products_match
+
+# Match wafw00f 1.0.0
+WAFW00F_REGEXP = r'The site http.* is behind {} WAF\.'
+
+products_match['http']['web-application-firewall'] = {
+    'aeSecure/aeSecure': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('aeSecure \(aeSecure\)'),
+        },
+    },
+    'Phion/Ergon/Airlock': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Airlock \(Phion/Ergon\)'),
+        },
+    },
+    'Alert Logic/Alert Logic': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Alert Logic \(Alert Logic\)'),
+        },
+    },
+    'Alibaba Cloud Computing/AliYunDun': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('AliYunDun \(Alibaba Cloud Computing\)'),
+        },
+    },
+    'Anquanbao/Anquanbao': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Anquanbao \(Anquanbao\)'),
+        },
+    },
+    'AnYu Technologies/AnYu': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('AnYu \(AnYu Technologies\)'),
+        },
+    },
+    'Approach/Approach': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Approach \(Approach\)'),
+        },
+    },
+    'Armor/Armor Defense': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Armor Defense \(Armor\)'),
+        },
+    },
+    'Microsoft/ASP.NET Generic Protection': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('ASP.NET Generic Protection \(Microsoft\)'),
+        },
+    },
+    'Czar Securities/Astra Web Protection': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Astra Web Protection \(Czar Securities\)'),
+        },
+    },
+    'Amazon/AWS Elastic Load Balancer': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('AWS Elastic Load Balancer \(Amazon\)'),
+        },
+    },
+    'Baidu Cloud Computing/Yunjiasu': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Yunjiasu \(Baidu Cloud Computing\)'),
+        },
+    },
+    'Ethic Ninja/Barikode': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Barikode \(Ethic Ninja\)'),
+        },
+    },
+    'Barracuda Networks/Barracuda Application Firewall': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Barracuda Application Firewall \(Barracuda Networks\)'),
+        },
+    },
+    'Faydata Technologies Inc./Bekchy': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Bekchy \(Faydata Technologies Inc\.\)'),
+        },
+    },
+    'BinarySec/BinarySec': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('BinarySec \(BinarySec\)'),
+        },
+    },
+    'BitNinja/BitNinja': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('BitNinja \(BitNinja\)'),
+        },
+    },
+    'BlockDoS/BlockDoS': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('BlockDoS \(BlockDoS\)'),
+        },
+    },
+    'Bluedon IST/Bluedon': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Bluedon \(Bluedon IST\)'),
+        },
+    },
+    'Varnish/CacheWall': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('CacheWall \(Varnish\)'),
+        },
+    },
+    'CdnNs/WdidcNet/CdnNS Application Gateway': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('CdnNS Application Gateway \(CdnNs/WdidcNet\)'),
+        },
+    },
+    'Cerber Tech/WP Cerber Security': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('WP Cerber Security \(Cerber Tech\)'),
+        },
+    },
+    'ChinaCache/ChinaCache CDN Load Balancer': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('ChinaCache CDN Load Balancer \(ChinaCache\)'),
+        },
+    },
+    'Yunaq/Chuang Yu Shield': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Chuang Yu Shield \(Yunaq\)'),
+        },
+    },
+    'Cisco/ACE XML Gateway': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('ACE XML Gateway \(Cisco\)'),
+        },
+    },
+    'Penta Security/Cloudbric': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Cloudbric \(Penta Security\)'),
+        },
+    },
+    'Cloudflare Inc./Cloudflare': {
+        'wappalyzer': 'CloudFlare',
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Cloudflare \(Cloudflare Inc\.\)'),
+        },
+    },
+    'Amazon/Cloudfront': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Cloudfront \(Amazon\)'),
+        },
+    },
+    'Comodo CyberSecurity/Comodo cWatch': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Comodo cWatch \(Comodo CyberSecurity\)'),
+        },
+    },
+    'Jean-Denis Brun/CrawlProtect': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('CrawlProtect \(Jean-Denis Brun\)'),
+        },
+    },
+    'Rohde & Schwarz CyberSecurity/DenyALL': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('DenyALL \(Rohde & Schwarz CyberSecurity\)'),
+        },
+    },
+    'Distil Networks/Distil': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Distil \(Distil Networks\)'),
+        },
+    },
+    'DOSarrest Internet Security/DOSarrest': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('DOSarrest \(DOSarrest Internet Security\)'),
+        },
+    },
+    'Applicure Technologies/DotDefender': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('DotDefender \(Applicure Technologies\)'),
+        },
+    },
+    'DynamicWeb/DynamicWeb Injection Check': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('DynamicWeb Injection Check \(DynamicWeb\)'),
+        },
+    },
+    'Verizon Digital Media/Edgecast': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Edgecast \(Verizon Digital Media\)'),
+        },
+    },
+    'EllisLab/Expression Engine': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Expression Engine \(EllisLab\)'),
+        },
+    },
+    'F5 Networks/BIG-IP Access Policy Manager': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('BIG-IP Access Policy Manager \(F5 Networks\)'),
+        },
+    },
+    'F5 Networks/BIG-IP Application Security Manager': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('BIG-IP Application Security Manager \(F5 Networks\)'),
+        },
+    },
+    'F5 Networks/BIG-IP Local Traffic Manager': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('BIG-IP Local Traffic Manager \(F5 Networks\)'),
+        },
+    },
+    'F5 Networks/FirePass': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('FirePass \(F5 Networks\)'),
+        },
+    },
+    'F5 Networks/Trafficshield': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Trafficshield \(F5 Networks\)'),
+        },
+    },
+    'Fortinet/FortiWeb': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('FortiWeb \(Fortinet\)'),
+        },
+    },
+    'GoDaddy/GoDaddy Website Protection': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('GoDaddy Website Protection \(GoDaddy\)'),
+        },
+    },
+    'Grey Wizard/Greywizard': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Greywizard \(Grey Wizard\)'),
+        },
+    },
+    'Art of Defense/HyperGuard': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('HyperGuard \(Art of Defense\)'),
+        },
+    },
+    'IBM/DataPower': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('DataPower \(IBM\)'),
+        },
+    },
+    'CloudLinux/Imunify360': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Imunify360 \(CloudLinux\)'),
+        },
+    },
+    'Imperva Inc./Incapsula': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Incapsula \(Imperva Inc\.\)'),
+        },
+    },
+    'Instart Logic/Instart DX': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Instart DX \(Instart Logic\)'),
+        },
+    },
+    'Microsoft/ISA Server': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('ISA Server \(Microsoft\)'),
+        },
+    },
+    'Janusec/Janusec Application Gateway': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Janusec Application Gateway \(Janusec\)'),
+        },
+    },
+    'Jiasule/Jiasule': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Jiasule \(Jiasule\)'),
+        },
+    },
+    'KnownSec/KS-WAF': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('KS-WAF \(KnownSec\)'),
+        },
+    },
+    'Akamai/Kona Site Defender': {
+        'wappalyzer': 'AkamaiGHost extrainfo: Akamai\'s HTTP',
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Kona Site Defender \(Akamai\)'),
+        },
+    },
+    'LiteSpeed Technologies/LiteSpeed Firewall': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('LiteSpeed Firewall \(LiteSpeed Technologies\)'),
+        },
+    },
+    'Inactiv/Malcare': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Malcare \(Inactiv\)'),
+        },
+    },
+    'Mission Control/Mission Control Application Shield': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Mission Control Application Shield \(Mission Control\)'),
+        },
+    },
+    'SpiderLabs/ModSecurity': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('ModSecurity \(SpiderLabs\)'),
+        },
+    },
+    'NBS Systems/NAXSI': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('NAXSI \(NBS Systems\)'),
+        },
+    },
+    'PentestIt/Nemesida': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Nemesida \(PentestIt\)'),
+        },
+    },
+    'Barracuda Networks/NetContinuum': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('NetContinuum \(Barracuda Networks\)'),
+        },
+    },
+    'Citrix Systems/NetScaler AppFirewall': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('NetScaler AppFirewall \(Citrix Systems\)'),
+        },
+    },
+    'AdNovum/NevisProxy': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('NevisProxy \(AdNovum\)'),
+        },
+    },
+    'NewDefend/Newdefend': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Newdefend \(NewDefend\)'),
+        },
+    },
+    'NexusGuard/NexusGuard Firewall': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('NexusGuard Firewall \(NexusGuard\)'),
+        },
+    },
+    'NinTechNet/NinjaFirewall': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('NinjaFirewall \(NinTechNet\)'),
+        },
+    },
+    'NSFocus Global Inc./NSFocus': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('NSFocus \(NSFocus Global Inc.\)'),
+        },
+    },
+    'BlackBaud/OnMessage Shield': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('OnMessage Shield \(BlackBaud\)'),
+        },
+    },
+    'Palo Alto Networks/Palo Alto Next Gen Firewall': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Palo Alto Next Gen Firewall \(Palo Alto Networks\)'),
+        },
+    },
+    'PerimeterX/PerimeterX': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('PerimeterX \(PerimeterX\)'),
+        },
+    },
+    'PowerCDN/PowerCDN': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('PowerCDN \(PowerCDN\)'),
+        },
+    },
+    'ArmorLogic/Profense': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Profense \(ArmorLogic\)'),
+        },
+    },
+    'Radware/AppWall': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('AppWall \(Radware\)'),
+        },
+    },
+    'Reblaze/Reblaze': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Reblaze \(Reblaze\)'),
+        },
+    },
+    'RSJoomla!/RSFirewall': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('RSFirewall \(RSJoomla\!\)'),
+        },
+    },
+    'Microsoft/ASP.NET RequestValidationMode': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('ASP.NET RequestValidationMode \(Microsoft\)'),
+        },
+    },
+    'Sabre/Sabre Firewall': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Sabre Firewall \(Sabre\)'),
+        },
+    },
+    'Safe3/Safe3 Web Firewall': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Safe3 Web Firewall \(Safe3\)'),
+        },
+    },
+    'SafeDog/Safedog': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Safedog \(SafeDog\)'),
+        },
+    },
+    'Chaitin Tech./Safeline': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Safeline \(Chaitin Tech.\)'),
+        },
+    },
+    'SecuPress/SecuPress WordPress Security': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('SecuPress WordPress Security \(SecuPress\)'),
+        },
+    },
+    'United Security Providers/Secure Entry': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Secure Entry \(United Security Providers\)'),
+        },
+    },
+    'BeyondTrust/eEye SecureIIS': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('eEye SecureIIS \(BeyondTrust\)'),
+        },
+    },
+    'Imperva Inc./SecureSphere': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('SecureSphere \(Imperva Inc\.\)'),
+        },
+    },
+    'Neusoft/SEnginx': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('SEnginx \(Neusoft\)'),
+        },
+    },
+    'One Dollar Plugin/Shield Security': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Shield Security \(One Dollar Plugin\)'),
+        },
+    },
+    'SiteGround/SiteGround': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('SiteGround \(SiteGround\)'),
+        },
+    },
+    'Sakura Inc./SiteGuard': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('SiteGuard \(Sakura Inc\.\)'),
+        },
+    },
+    'TrueShield/Sitelock': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Sitelock \(TrueShield\)'),
+        },
+    },
+    'Dell/SonicWall': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('SonicWall \(Dell\)'),
+        },
+    },
+    'Sophos/UTM Web Protection': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('UTM Web Protection \(Sophos\)'),
+        },
+    },
+    'Squarespace/Squarespace': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Squarespace \(Squarespace\)'),
+        },
+    },
+    'StackPath/StackPath': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('StackPath \(StackPath\)'),
+        },
+    },
+    'Sucuri Inc./Sucuri CloudProxy': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Sucuri CloudProxy \(Sucuri Inc\.\)'),
+        },
+    },
+    'Tencent Technologies/Tencent Cloud Firewall': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Tencent Cloud Firewall \(Tencent Technologies\)'),
+        },
+    },
+    'Citrix Systems/Teros': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Teros \(Citrix Systems\)'),
+        },
+    },
+    'TransIP/TransIP Web Firewall': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('TransIP Web Firewall \(TransIP\)'),
+        },
+    },
+    'iFinity/DotNetNuke/URLMaster SecurityCheck': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('URLMaster SecurityCheck \(iFinity/DotNetNuke\)'),
+        },
+    },
+    'Microsoft/URLScan': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('URLScan \(Microsoft\)'),
+        },
+    },
+    'OWASP/Varnish': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Varnish \(OWASP\)'),
+        },
+    },
+    'VirusDie LLC/VirusDie': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('VirusDie \(VirusDie LLC\)'),
+        },
+    },
+    'Wallarm Inc./Wallarm': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Wallarm \(Wallarm Inc\.\)'),
+        },
+    },
+    'WatchGuard Technologies/WatchGuard': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('WatchGuard \(WatchGuard Technologies\)'),
+        },
+    },
+    'WebARX Security Solutions/WebARX': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('WebARX \(WebARX Security Solutions\)'),
+        },
+    },
+    'AQTRONIX/WebKnight': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('WebKnight \(AQTRONIX\)'),
+        },
+    },
+    'IBM/WebSEAL': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('WebSEAL \(IBM\)'),
+        },
+    },
+    'WebTotem/WebTotem': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('WebTotem \(WebTotem\)'),
+        },
+    },
+    'Feedjit/Wordfence': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Wordfence \(Feedjit\)'),
+        },
+    },
+    'WTS/WTS-WAF': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('WTS-WAF \(WTS\)'),
+        },
+    },
+    '360 Technologies/360WangZhanBao': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('360WangZhanBao \(360 Technologies\)'),
+        },
+    },
+    'XLabs/XLabs Security WAF': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('XLabs Security WAF \(XLabs\)'),
+        },
+    },
+    'Yundun/Yundun': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Yundun \(Yundun\)'),
+        },
+    },
+    'Yunsuo/Yunsuo': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Yunsuo \(Yunsuo\)'),
+        },
+    },
+    'Zenedge/Zenedge': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Zenedge \(Zenedge\)'),
+        },
+    },
+    'Accenture/ZScaler': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('ZScaler \(Accenture\)'),
+        },
+    },
+    'Accenture/ZScaler': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('ZScaler \(Accenture\)'),
+        },
+    },
+    'West263 Content Delivery Network': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('West263 Content Delivery Network'),
+        },
+    },
+    'pkSecurity Intrusion Detection System': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('pkSecurity Intrusion Detection System'),
+        },
+    },   
+    'Xuanwudun': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Xuanwudun'),
+        },
+    },   
+    'Open-Resty Lua Nginx WAF': {
+        'wafw00f': {
+            WAFW00F_REGEXP.format('Open-Resty Lua Nginx WAF'),
+        },
+    },
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ six>=1.11.0
 SQLAlchemy>=1.2.8
 SQLAlchemy-Utils>=0.33.3
 urllib3
+tld

--- a/settings/http.conf
+++ b/settings/http.conf
@@ -71,6 +71,128 @@ web-language =
     Python,
     Ruby
 
+web-application-firewall =
+    aeSecure/aeSecure,
+    Phion/Ergon/Airlock,
+    Alert Logic/Alert Logic,
+    Alibaba Cloud Computing/AliYunDun,
+    Anquanbao/Anquanbao,
+    AnYu Technologies/AnYu,
+    Approach/Approach,
+    Armor/Armor Defense,
+    Microsoft/ASP.NET Generic Protection,
+    Czar Securities/Astra Web Protection,
+    Amazon/AWS Elastic Load Balancer,
+    Baidu Cloud Computing/Yunjiasu,
+    Ethic Ninja/Barikode,
+    Barracuda Networks/Barracuda Application Firewall,
+    Faydata Technologies Inc./Bekchy,
+    BinarySec/BinarySec,
+    BitNinja/BitNinja,
+    BlockDoS/BlockDoS,
+    Bluedon IST/Bluedon,
+    Varnish/CacheWall,
+    CdnNs/WdidcNet/CdnNS Application Gateway,
+    Cerber Tech/WP Cerber Security,
+    ChinaCache/ChinaCache CDN Load Balancer,
+    Yunaq/Chuang Yu Shield,
+    Cisco/ACE XML Gateway,
+    Penta Security/Cloudbric,
+    Cloudflare Inc./Cloudflare,
+    Amazon/Cloudfront,
+    Comodo CyberSecurity/Comodo cWatch,
+    Jean-Denis Brun/CrawlProtect,
+    Rohde & Schwarz CyberSecurity/DenyALL,
+    Distil Networks/Distil,
+    DOSarrest Internet Security/DOSarrest,
+    Applicure Technologies/DotDefender,
+    DynamicWeb/DynamicWeb Injection Check,
+    Verizon Digital Media/Edgecast,
+    EllisLab/Expression Engine,
+    F5 Networks/BIG-IP Access Policy Manager,
+    F5 Networks/BIG-IP Application Security Manager,
+    F5 Networks/BIG-IP Local Traffic Manager,
+    F5 Networks/FirePass,
+    F5 Networks/Trafficshield,
+    Fortinet/FortiWeb,
+    GoDaddy/GoDaddy Website Protection,
+    Grey Wizard/Greywizard,
+    Art of Defense/HyperGuard,
+    IBM/DataPower,
+    CloudLinux/Imunify360,
+    Imperva Inc./Incapsula,
+    Instart Logic/Instart DX,
+    Microsoft/ISA Server,
+    Janusec/Janusec Application Gateway,
+    Jiasule/Jiasule,
+    KnownSec/KS-WAF,
+    Akamai/Kona Site Defender,
+    LiteSpeed Technologies/LiteSpeed Firewall,
+    Inactiv/Malcare,
+    Mission Control/Mission Control Application Shield,
+    SpiderLabs/ModSecurity,
+    NBS Systems/NAXSI,
+    PentestIt/Nemesida,
+    Barracuda Networks/NetContinuum,
+    Citrix Systems/NetScaler AppFirewall,
+    AdNovum/NevisProxy,
+    NewDefend/Newdefend,
+    NexusGuard/NexusGuard Firewall,
+    NinTechNet/NinjaFirewall,
+    NSFocus Global Inc./NSFocus,
+    BlackBaud/OnMessage Shield,
+    Palo Alto Networks/Palo Alto Next Gen Firewall,
+    PerimeterX/PerimeterX,
+    PowerCDN/PowerCDN,
+    ArmorLogic/Profense,
+    Radware/AppWall,
+    Reblaze/Reblaze,
+    RSJoomla!/RSFirewall,
+    Microsoft/ASP.NET RequestValidationMode,
+    Sabre/Sabre Firewall,
+    Safe3/Safe3 Web Firewall,
+    SafeDog/Safedog,
+    Chaitin Tech./Safeline,
+    SecuPress/SecuPress WordPress Security,
+    United Security Providers/Secure Entry,
+    BeyondTrust/eEye SecureIIS,
+    Imperva Inc./SecureSphere,
+    Neusoft/SEnginx,
+    One Dollar Plugin/Shield Security,
+    SiteGround/SiteGround,
+    Sakura Inc./SiteGuard,
+    TrueShield/Sitelock,
+    Dell/SonicWall,
+    Sophos/UTM Web Protection,
+    Squarespace/Squarespace,
+    StackPath/StackPath,
+    Sucuri Inc./Sucuri CloudProxy,
+    Tencent Technologies/Tencent Cloud Firewall,
+    Citrix Systems/Teros,
+    TransIP/TransIP Web Firewall,
+    iFinity/DotNetNuke/URLMaster SecurityCheck,
+    Microsoft/URLScan,
+    OWASP/Varnish,
+    VirusDie LLC/VirusDie,
+    Wallarm Inc./Wallarm,
+    WatchGuard Technologies/WatchGuard,
+    WebARX Security Solutions/WebARX,
+    AQTRONIX/WebKnight,
+    IBM/WebSEAL,
+    WebTotem/WebTotem,
+    Feedjit/Wordfence,
+    WTS/WTS-WAF,
+    360 Technologies/360WangZhanBao,
+    XLabs/XLabs Security WAF,
+    Yundun/Yundun,
+    Yunsuo/Yunsuo,
+    Zenedge/Zenedge,
+    Accenture/ZScaler,
+    West263 Content Delivery Network,
+    pkSecurity Intrusion Detection System,
+    Xuanwudun,
+    Open-Resty Lua Nginx WAF
+
 web-framework =
     Bootstrap,
     Angular Material,
@@ -299,19 +421,12 @@ description = Recon using Nmap HTTP scripts
 tool        = nmap
 command_1   = sudo nmap -sT -sV -Pn -vv -p [PORT] --script-args=unsafe=1 --script='http-adobe-coldfusion-apsa1301,http-apache-negotiation,http-apache-server-status,http-aspnet-debug,http-auth-finder,http-axis2-dir-traversal,http-bigip-cookie,http-cakephp-version,http-coldfusion-subzero,http-comments-displayer,http-cookie-flags,http-cors,http-cross-domain-policy,http-errors,http-favicon,http-generator,http-git,http-iis-webdav-vuln,http-mcmp,http-methods,http-method-tamper,http-mobileversion-checker,http-ntlm-info,http-passwd,http-phpmyadmin-dir-traversal,http-phpself-xss,http-php-version,http-put,http-robots.txt,http-security-headers,http-server-header,http-shellshock,http-svn-enum,http-svn-info,http-title,http-trace,http-vuln*,http-webdav-scan,weblogic-t3-info' --script-args http.useragent='Mozilla/5.0 (Windows NT 6.1; WOW64; rv:64.0) Gecko/20100101 Firefox/64.0' --stats-every 10s -d [IP]
 
-[check_load-balancing-detection]
-name        = load-balancing-detection
-category    = recon
-description = HTTP load balancer detection
-tool        = halberd
-command_1   = ./build/scripts-2.7/halberd -v [URL]
-
 [check_waf-detection]
 name        = waf-detection
 category    = recon
 description = Identify and fingerprint WAF products protecting website
 tool        = wafw00f
-command_1   = ./build/scripts-2.7/wafw00f -v -a [URL]
+command_1   = ./build/scripts-3.7/wafw00f -v -a [URL]
 
 [check_waf-detection2]
 name        = waf-detection2
@@ -319,6 +434,21 @@ category    = recon
 description = Identify and fingerprint WAF products protecting website
 tool        = identifywaf
 command_1   = python3 identYwaf.py [URL]
+
+[check_cloudmare-recon]
+name        = cloudmare-recon
+category    = recon
+description = Try to find real ip behind cloudflare
+tool        = cloudmare
+context_1   = { 'web-application-firewall': 'Cloudflare Inc./Cloudflare'}
+command_1   = python2.7 Cloudmare.py -s [DOMAIN]
+
+[check_load-balancing-detection]
+name        = load-balancing-detection
+category    = recon
+description = HTTP load balancer detection
+tool        = halberd
+command_1   = ./build/scripts-2.7/halberd -v [URL]
 
 # [check_tls-probing]
 # name        = tls-probing

--- a/settings/toolbox.conf
+++ b/settings/toolbox.conf
@@ -182,13 +182,21 @@ install        = git clone https://github.com/jmbr/halberd.git . && sudo python2
 update         = git pull && sudo python setup.py install
 check_command  = ./build/scripts-2.7/halberd -h
 
+[cloudmare]
+name           = cloudmare
+description    = CloudFlare real IP catcher
+target_service = http
+install        = git clone https://github.com/MrH0wl/Cloudmare.git . && sudo pip2 install -r requirements.txt
+update         = git pull && sudo pip2 install -r requirements.txt
+check_command  = python2.7 Cloudmare.py -v
+
 [wafw00f]
 name           = wafw00f
 description    = Identify and fingerprint WAF products protecting a website
 target_service = http
-install        = git clone https://github.com/sandrogauci/wafw00f.git . && sudo python2.7 setup.py install
-update         = git pull && sudo python2.7 setup.py install
-check_command  = ./build/scripts-2.7/wafw00f -h
+install        = git clone https://github.com/EnableSecurity/wafw00f . && sudo python3.7 setup.py install
+update         = git pull && sudo python3.7 setup.py install
+check_command  = ./build/scripts/scripts-3.7/wafw00f -h
 
 [identifywaf]
 name           = identifywaf


### PR DESCRIPTION
I take Cloudflare context from wafw00f and wappanalyzer for the moment.

I then check the root domain on cloudmare, i fetch the root domain with a tricky way, if you can provider a placeholder like [DOMAIN] it would be nice.

